### PR TITLE
docs: deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⚠️ This project is deprecated in favor of [oniguruma-to-es](https://github.com/slevithan/oniguruma-to-es). Please migrate over.
+
 # onigurumajs
 
 [![Build Status](https://travis-ci.org/bcoe/onigurumajs.svg)](https://travis-ci.org/bcoe/onigurumajs)


### PR DESCRIPTION
Per request in #5, this adds a deprecation notice with a link to oniguruma-to-es. Happy to adjust the message if you prefer.